### PR TITLE
Remove `DEFAULT_CIPHERS`

### DIFF
--- a/download.py
+++ b/download.py
@@ -35,8 +35,6 @@ post = {
     "_excludeFukaikoFlg": 1,
 }
 
-requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += "HIGH:!DH:!aNULL"
-
 kdb_url = "https://kdb.tsukuba.ac.jp/"
 session = requests.session()
 response = session.get(kdb_url)


### PR DESCRIPTION
## 動機

以下の行を削除した場合においても、私の手元の環境では download.py は動いた。

```diff
- requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += "HIGH:!DH:!aNULL"
```

上記のことに加え、urllib3 の 2系 では `DEFAULT_CIPHERS` が削除されたことを鑑みると、`DEFAULT_CIPHERS` を削除してよいと思う。